### PR TITLE
fix(entrypoint): make app_entry delegate to the canonical GUI main

### DIFF
--- a/paper_grouper/app_entry.py
+++ b/paper_grouper/app_entry.py
@@ -1,8 +1,12 @@
-"""
-Future GUI entrypoint (PySide6).
-Right now it's just a placeholder.
-"""
+"""Canonical GUI entrypoint for Paper Grouper."""
+
+from paper_grouper.ui.main_window import main as gui_main
 
 
-def main():
-    print("paper_grouper GUI stub. (PySide6)")
+def main() -> None:
+    """Run the official GUI entrypoint."""
+    gui_main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Make `paper_grouper/app_entry.py` delegate to `paper_grouper.ui.main_window.main()` so the project has a canonical GUI entrypoint.

## Why
The repository already has the actual GUI in `paper_grouper/ui/main_window.py`, but `paper_grouper/app_entry.py` is still a stub. This PR makes the official entrypoint match the real application entry.

## Scope
- update `paper_grouper/app_entry.py`

## Out of scope
- clustering logic
- autotune logic
- metadata extraction
- output directory contract
- UI behavior changes beyond the entrypoint delegation

## Validation
- `python -m py_compile paper_grouper/app_entry.py paper_grouper/ui/main_window.py`
- import smoke test for `paper_grouper.app_entry.main`
