### PR TITLE
chore(tooling): quarantine Teste-Matheus from style checks

### DIFF
--- a/paper_grouper/core/autotune.py
+++ b/paper_grouper/core/autotune.py
@@ -62,9 +62,7 @@ def run_autotune(
 
     results = []
     with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as pool:
-        futs = [
-            pool.submit(_evaluate_single_config, cfg, articles, emb) for cfg in configs
-        ]
+        futs = [pool.submit(_evaluate_single_config, cfg, articles, emb) for cfg in configs]
         for fut in concurrent.futures.as_completed(futs):
             results.append(fut.result())
 

--- a/paper_grouper/core/cluster_postprocess.py
+++ b/paper_grouper/core/cluster_postprocess.py
@@ -48,9 +48,7 @@ def _merge_tiny_clusters(
     return new_assign
 
 
-def _compute_centrality(
-    G: nx.Graph, clusters: Dict[int, List[str]]
-) -> Dict[str, float]:
+def _compute_centrality(G: nx.Graph, clusters: Dict[int, List[str]]) -> Dict[str, float]:
     centrality: Dict[str, float] = {}
     for _cid, members in clusters.items():
         member_set = set(members)
@@ -63,9 +61,7 @@ def _compute_centrality(
     return centrality
 
 
-def _label_cluster(
-    cid: int, members: List[str], by_id: Dict[str, ArticleRecord]
-) -> str:
+def _label_cluster(cid: int, members: List[str], by_id: Dict[str, ArticleRecord]) -> str:
     bag = []
     for art_id in members:
         a = by_id[art_id]

--- a/paper_grouper/core/embedder.py
+++ b/paper_grouper/core/embedder.py
@@ -43,9 +43,7 @@ def _text_to_vec_hash(text: str, dim: int = 64) -> np.ndarray:
     return vec
 
 
-def embed_articles_light(
-    articles: List[ArticleRecord], dim: int = 64
-) -> EmbeddingResult:
+def embed_articles_light(articles: List[ArticleRecord], dim: int = 64) -> EmbeddingResult:
     """
     Modo leve (sem torch). Útil para desenvolvimento rápido.
     """

--- a/paper_grouper/io/file_scanner.py
+++ b/paper_grouper/io/file_scanner.py
@@ -4,8 +4,4 @@ from typing import List
 
 def list_pdfs(folder: str) -> List[str]:
     p = Path(folder)
-    return [
-        str(f.resolve())
-        for f in p.iterdir()
-        if f.is_file() and f.suffix.lower() == ".pdf"
-    ]
+    return [str(f.resolve()) for f in p.iterdir() if f.is_file() and f.suffix.lower() == ".pdf"]

--- a/paper_grouper/ui/main_window.py
+++ b/paper_grouper/ui/main_window.py
@@ -112,9 +112,7 @@ class MainWindow(QMainWindow):
         self.k_spin.setMinimum(1)
         self.k_spin.setMaximum(100)
         self.k_spin.setValue(8)
-        self.k_spin.setToolTip(
-            "Número de vizinhos mais próximos usados no grafo de similaridade."
-        )
+        self.k_spin.setToolTip("Número de vizinhos mais próximos usados no grafo de similaridade.")
 
         self.resolution_spin = QDoubleSpinBox()
         self.resolution_spin.setDecimals(2)
@@ -123,8 +121,7 @@ class MainWindow(QMainWindow):
         self.resolution_spin.setMaximum(5.0)
         self.resolution_spin.setValue(1.0)
         self.resolution_spin.setToolTip(
-            "Resolução do algoritmo de comunidade (Louvain). "
-            "Maior => mais clusters menores."
+            "Resolução do algoritmo de comunidade (Louvain). " "Maior => mais clusters menores."
         )
 
         self.min_cluster_spin = QSpinBox()
@@ -175,13 +172,9 @@ class MainWindow(QMainWindow):
         self.workers_spin.setMinimum(1)
         self.workers_spin.setMaximum(32)
         self.workers_spin.setValue(4)
-        self.workers_spin.setToolTip(
-            "Quantas configurações testar em paralelo no modo automático."
-        )
+        self.workers_spin.setToolTip("Quantas configurações testar em paralelo no modo automático.")
 
-        auto_form_layout.addRow(
-            "Lista de k (separado por vírgula):", self.k_values_edit
-        )
+        auto_form_layout.addRow("Lista de k (separado por vírgula):", self.k_values_edit)
         auto_form_layout.addRow("Lista de resoluções Louvain:", self.resolutions_edit)
         auto_form_layout.addRow(
             "Lista de tamanhos mínimos de cluster:", self.min_cluster_values_edit
@@ -361,9 +354,7 @@ class MainWindow(QMainWindow):
         try:
             k_values = self._parse_int_list(self.k_values_edit.text())
             resolutions = self._parse_float_list(self.resolutions_edit.text())
-            min_cluster_values = self._parse_int_list(
-                self.min_cluster_values_edit.text()
-            )
+            min_cluster_values = self._parse_int_list(self.min_cluster_values_edit.text())
             workers = self.workers_spin.value()
 
             result = app_controller.run_auto(
@@ -405,9 +396,7 @@ class MainWindow(QMainWindow):
         self._append_result("\nQualidade do agrupamento:")
         self._append_result(f"- Score final: {score_final}")
         self._append_result(f"- Nº de clusters: {n_clusters}")
-        self._append_result(
-            f"- Fração maior cluster: {summary.get('max_cluster_fraction')}"
-        )
+        self._append_result(f"- Fração maior cluster: {summary.get('max_cluster_fraction')}")
         self._append_result(f"- Modularity: {summary.get('modularity')}")
         self._append_result(f"- Balance score: {summary.get('balance_score')}")
 
@@ -416,9 +405,7 @@ class MainWindow(QMainWindow):
             self._append_result("\nMelhor configuração encontrada (auto-tune):")
             self._append_result(f"  k = {best_cfg.get('k')}")
             self._append_result(f"  resolução = {best_cfg.get('resolution')}")
-            self._append_result(
-                f"  min_cluster_size = {best_cfg.get('min_cluster_size')}"
-            )
+            self._append_result(f"  min_cluster_size = {best_cfg.get('min_cluster_size')}")
 
         clustering = result_dict.get("clustering")
         articles_by_id = result_dict.get("articles", {})
@@ -433,9 +420,7 @@ class MainWindow(QMainWindow):
                     key=lambda aid: clustering.centrality.get(aid, 0.0),
                     reverse=True,
                 )
-                self._append_result(
-                    f"\n▶ {label}  (Cluster {cid}, {len(members)} artigos)"
-                )
+                self._append_result(f"\n▶ {label}  (Cluster {cid}, {len(members)} artigos)")
                 for aid in ranked[:2]:
                     art = articles_by_id.get(aid)
                     if not art:
@@ -447,9 +432,7 @@ class MainWindow(QMainWindow):
             self._append_result("\nDetalhamento dos clusters:")
             for cid, members in clustering.clusters.items():
                 label = clustering.cluster_labels.get(cid, f"cluster_{cid}")
-                self._append_result(
-                    f"\n▶ Cluster {cid} :: {label} (size={len(members)})"
-                )
+                self._append_result(f"\n▶ Cluster {cid} :: {label} (size={len(members)})")
                 ranked = sorted(
                     members,
                     key=lambda aid: clustering.centrality.get(aid, 0.0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,19 @@ types-setuptools = "^75.8.2.20250305"
 
 [tool.ruff]
 line-length = 100
+extend-exclude = ["Teste-Matheus"]
+force-exclude = true
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
 ignore = ["E501"]
+
+
+[tool.black]
+line-length = 100
+force-exclude = '''
+(^/Teste-Matheus/)
+'''
 
 [tool.pytest.ini_options]
 addopts = "-q"


### PR DESCRIPTION
## Summary
Exclude the tracked experimental `Teste-Matheus/` tree from style checks.

## Why
The CI currently runs `ruff` and `black` against the whole repository. The tracked `Teste-Matheus/maluco.py` file is experimental debt already present on `main`, and it is blocking unrelated, minimal PRs.

## Scope
- update `pyproject.toml`
- quarantine `Teste-Matheus/` from `ruff` and `black`

## Out of scope
- refactoring or fixing `Teste-Matheus/maluco.py`
- application logic
- clustering / autotune / metadata extraction / output changes

## Validation
- `poetry run ruff check paper_grouper tests`
- `poetry run black --check paper_grouper tests`
- `poetry run pytest -q`
